### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/app/src/main/java/bf/io/openshop/SettingsMy.java
+++ b/app/src/main/java/bf/io/openshop/SettingsMy.java
@@ -29,6 +29,8 @@ public class SettingsMy {
     private static User activeUser;
     private static SharedPreferences sharedPref;
 
+    private SettingsMy() {}
+
     /**
      * Get actually selected shop.
      *

--- a/app/src/main/java/bf/io/openshop/api/EndPoints.java
+++ b/app/src/main/java/bf/io/openshop/api/EndPoints.java
@@ -46,4 +46,6 @@ public class EndPoints {
     public static final String NOTIFICATION_IMAGE_URL   = "image_url";
     public static final String NOTIFICATION_SHOP_ID     = "shop_id";
     public static final String NOTIFICATION_UTM         = "utm";
+
+    private EndPoints() {}
 }

--- a/app/src/main/java/bf/io/openshop/utils/Analytics.java
+++ b/app/src/main/java/bf/io/openshop/utils/Analytics.java
@@ -31,6 +31,8 @@ public class Analytics {
     private static AppEventsLogger facebookLogger;
     private static String campaignUri;
 
+    private Analytics() {}
+
     /**
      * Prepare Google analytics trackers and Facebook events logger.
      * Send UTM campaign if exist.

--- a/app/src/main/java/bf/io/openshop/utils/JsonUtils.java
+++ b/app/src/main/java/bf/io/openshop/utils/JsonUtils.java
@@ -44,6 +44,8 @@ public class JsonUtils {
     public static final String TAG_SHIPPING_PRICE_FORMATTED = "shipping_price_formatted";
     public static final String TAG_NOTE = "note";
 
+    private JsonUtils() {}
+
 
     /**
      * @param order

--- a/app/src/main/java/bf/io/openshop/utils/Utils.java
+++ b/app/src/main/java/bf/io/openshop/utils/Utils.java
@@ -32,6 +32,8 @@ public class Utils {
 
     private static Gson gson;
 
+    private Utils() {}
+
     /**
      * Add specific parsing to gson
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
